### PR TITLE
改造redis连接方式支持哨兵模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <dependency>
   <groupId>cc.ddrpa.repack</groupId>
   <artifactId>taptap-ratelimiter-spring-boot-starter</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
 <dependency>
 ```
 
@@ -19,6 +19,8 @@
     - 如果使用 RateLimiterService，可以显式调用 `RateLimiterService#revoke` 方法
     - 如果使用 `@RateLimit` 注解，当业务代码抛出实现 `com.taptap.ratelimiter.exception.RevocableExceptionInterface` 的异常时，将会撤销计数
 - 换成了比较习惯的 Maven
+
+- 2025-01，引入依赖`redisson-spring-boot-starter` 需要注意spring boot 2.x,3.x区别，移除`spring.ratelimiter.redis*`相关配置，仅仅保留`spring.ratelimiter.enabled`,使用默认通用的spring redis配置项，相关配置见[redission官方文档](https://redisson.org/docs/integration-with-spring/)
 
 开发在 [ddrpa-forked-master 分支](https://github.com/ddrpa/ratelimiter-spring-boot-starter/tree/ddrpa-forked-master) 上进行，以便后期选择性 PR（如果有的话）。
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>cc.ddrpa.repack</groupId>
   <artifactId>taptap-ratelimiter-spring-boot-starter</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>开箱即用的分布式限流器</description>
@@ -40,8 +40,8 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <redisson.version>3.15.1</redisson.version>
-    <springframework.boot.version>2.4.3</springframework.boot.version>
+    <redisson.version>3.18.1</redisson.version>
+    <springframework.boot.version>2.7.18</springframework.boot.version>
   </properties>
 
   <scm>
@@ -65,11 +65,32 @@
   </distributionManagement>
 
   <dependencies>
+
     <dependency>
       <groupId>org.redisson</groupId>
-      <artifactId>redisson</artifactId>
+      <artifactId>redisson-spring-boot-starter</artifactId>
+      <version>${redisson.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>redisson-spring-data-30</artifactId>
+          <groupId>org.redisson</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!--
+    https://redisson.org/docs/integration-with-spring/
+      redisson-spring-data-3x 适配 springboot 3.x
+      redisson-spring-data-2x 适配 springboot 2.x
+    -->
+
+    <dependency>
+      <groupId>org.redisson</groupId>
+      <artifactId>redisson-spring-data-22</artifactId>
       <version>${redisson.version}</version>
     </dependency>
+
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-aop</artifactId>
@@ -110,7 +131,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -123,7 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/src/main/java/com/taptap/ratelimiter/configuration/RateLimiterAutoConfiguration.java
+++ b/src/main/java/com/taptap/ratelimiter/configuration/RateLimiterAutoConfiguration.java
@@ -29,36 +29,14 @@ import org.springframework.context.annotation.Import;
 @Import({RateLimitAspectHandler.class, RateLimitExceptionHandler.class})
 public class RateLimiterAutoConfiguration {
 
-    private final RateLimiterProperties limiterProperties;
-    public final static String REDISSON_BEAN_NAME = "rateLimiterRedissonBeanName";
-
-    public RateLimiterAutoConfiguration(RateLimiterProperties limiterProperties) {
-        this.limiterProperties = limiterProperties;
-    }
-
-    @Bean(name = REDISSON_BEAN_NAME, destroyMethod = "shutdown")
-    RedissonClient redisson() {
-        Config config = new Config();
-        if (limiterProperties.getRedisClusterServer() != null) {
-            config.useClusterServers().setPassword(limiterProperties.getRedisPassword())
-                    .addNodeAddress(limiterProperties.getRedisClusterServer().getNodeAddresses());
-        } else {
-            config.useSingleServer().setAddress(limiterProperties.getRedisAddress())
-                    .setDatabase(limiterProperties.getRedisDatabase())
-                    .setPassword(limiterProperties.getRedisPassword());
-        }
-        config.setEventLoopGroup(new NioEventLoopGroup());
-        return Redisson.create(config);
-    }
-
     @Bean
     public RuleProvider bizKeyProvider() {
         return new RuleProvider();
     }
 
     @Bean
-    public RateLimiterService rateLimiterInfoProvider() {
-        return new RateLimiterService(redisson());
+    public RateLimiterService rateLimiterInfoProvider(RedissonClient redissonClient) {
+        return new RateLimiterService(redissonClient);
     }
 
 }

--- a/src/main/java/com/taptap/ratelimiter/configuration/RateLimiterProperties.java
+++ b/src/main/java/com/taptap/ratelimiter/configuration/RateLimiterProperties.java
@@ -10,11 +10,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class RateLimiterProperties {
 
     public static final String PREFIX = "spring.ratelimiter";
-    //redisson
-    private String redisAddress;
-    private String redisPassword;
-    private int redisDatabase = 1;
-    private ClusterServer redisClusterServer;
 
     private int statusCode = 429;
     private String responseBody = "{\"code\":429,\"msg\":\"Too Many Requests\"}";
@@ -35,48 +30,4 @@ public class RateLimiterProperties {
         this.responseBody = responseBody;
     }
 
-    public String getRedisAddress() {
-        return redisAddress;
-    }
-
-    public void setRedisAddress(String redisAddress) {
-        this.redisAddress = redisAddress;
-    }
-
-    public String getRedisPassword() {
-        return redisPassword;
-    }
-
-    public void setRedisPassword(String redisPassword) {
-        this.redisPassword = redisPassword;
-    }
-
-    public int getRedisDatabase() {
-        return redisDatabase;
-    }
-
-    public void setRedisDatabase(int redisDatabase) {
-        this.redisDatabase = redisDatabase;
-    }
-
-    public ClusterServer getRedisClusterServer() {
-        return redisClusterServer;
-    }
-
-    public void setRedisClusterServer(ClusterServer redisClusterServer) {
-        this.redisClusterServer = redisClusterServer;
-    }
-
-    public static class ClusterServer{
-
-        private String[] nodeAddresses;
-
-        public String[] getNodeAddresses() {
-            return nodeAddresses;
-        }
-
-        public void setNodeAddresses(String[] nodeAddresses) {
-            this.nodeAddresses = nodeAddresses;
-        }
-    }
 }

--- a/src/main/java/com/taptap/ratelimiter/core/TimeWindowRateLimiter.java
+++ b/src/main/java/com/taptap/ratelimiter/core/TimeWindowRateLimiter.java
@@ -7,12 +7,10 @@ import org.redisson.api.RScript;
 import org.redisson.api.RScript.ReturnType;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.LongCodec;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 import java.util.Collections;
 import java.util.List;
 
-import static com.taptap.ratelimiter.configuration.RateLimiterAutoConfiguration.REDISSON_BEAN_NAME;
 
 /**
  * @author kl (http://kailing.pub)
@@ -22,7 +20,7 @@ public class TimeWindowRateLimiter implements RateLimiter {
 
     private final RScript rScript;
 
-    public TimeWindowRateLimiter(@Qualifier(REDISSON_BEAN_NAME) RedissonClient client) {
+    public TimeWindowRateLimiter(RedissonClient client) {
         this.rScript = client.getScript(LongCodec.INSTANCE);
     }
 


### PR DESCRIPTION
引入redisson-spring-boot-starter，升级redisson、spring boot，maven插件
使用默认的spring-redis配置项，支持哨兵模式的redis，使用公共默认Redisson客户端

移除`spring.ratelimiter.redis*`相关配置，仅仅保留`spring.ratelimiter.enabled`,使用默认通用的spring redis配置项，相关配置见[redission官方文档](https://redisson.org/docs/integration-with-spring/)